### PR TITLE
fix: alpine 3.16 support for ext-intl

### DIFF
--- a/apache/Dockerfile.twig
+++ b/apache/Dockerfile.twig
@@ -26,6 +26,7 @@ RUN set -x && \
       apache2-proxy \
       shadow \
       gnu-libiconv \
+      icu-data-full \
       socat && \
     install-php-extensions bcmath gd intl mysqli pdo_mysql sockets bz2 gmp soap zip gmp redis imagick calendar {% if phpVersionNumeric >= 74 %} ffi {% endif %} {% if production %} opcache {% endif %} {% if xdebug %} xdebug{% if phpVersionNumeric >= 71 and xdebug == 2 %}-2.9.8{% endif %}{% endif %} && \
     ln -s /usr/local/bin/php /usr/bin/php && \

--- a/nginx/Dockerfile.twig
+++ b/nginx/Dockerfile.twig
@@ -24,6 +24,7 @@ RUN set -x && \
       nginx \
       shadow \
       gnu-libiconv \
+      icu-data-full \
       socat && \
     install-php-extensions bcmath gd intl mysqli pdo_mysql sockets bz2 gmp soap zip opcache redis calendar {% if phpVersionNumeric < 81 %}imagick {% endif%} {% if phpVersionNumeric >= 74 %} ffi {% endif %} {% if xdebug %} xdebug{% if phpVersionNumeric >= 71 and xdebug == 2 %}-2.9.8{% endif %}{% endif %} && \
     ln -s /usr/local/bin/php /usr/bin/php && \


### PR DESCRIPTION
> The latest official php images [are now based on Alpine 3.16](https://hub.docker.com/_/php?tab=tags&page=1&name=8.1-fpm-alpine), which ships with ICU 71.1 (vs 69.1 in Alpine 3.15). This breaks date & currency formatting, since only english locale is now included by default.


This is referenced to https://github.com/api-platform/api-platform/pull/2201
